### PR TITLE
Permit conversion into and creation from parts.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic
+Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed
+
+- Permit conversion into and creation from "parts"
+  [#2](https://github.com/mxinden/asynchronous-codec/pull/2).
+
+## [0.5.0] - 2021-01-06
+
+### Changed
+
+- Update to `bytes` `v1` and `pin-project-lite` `v0.2`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "asynchronous-codec"
 edition = "2018"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Max Inden <mail@max-inden.de>"]
 description = "Utilities for encoding and decoding frames using `async/await`"
 license = "MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,12 +37,12 @@ mod encoder;
 pub use encoder::Encoder;
 
 mod framed;
-pub use framed::Framed;
+pub use framed::{Framed, FramedParts};
 
 mod framed_read;
-pub use framed_read::FramedRead;
+pub use framed_read::{FramedRead, FramedReadParts};
 
 mod framed_write;
-pub use framed_write::FramedWrite;
+pub use framed_write::{FramedWrite, FramedWriteParts};
 
 mod fuse;

--- a/tests/framed_write.rs
+++ b/tests/framed_write.rs
@@ -57,7 +57,7 @@ fn line_write() {
     let mut framer = FramedWrite::new(curs, LinesCodec {});
     executor::block_on(framer.send("Hello\n".to_owned())).unwrap();
     executor::block_on(framer.send("World\n".to_owned())).unwrap();
-    let (curs, _) = framer.release();
+    let curs = framer.into_inner();
     assert_eq!(&curs.get_ref()[0..12], b"Hello\nWorld\n");
     assert_eq!(curs.position(), 12);
 }
@@ -69,7 +69,7 @@ fn line_write_to_eof() {
     let mut framer = FramedWrite::new(curs, LinesCodec {});
     let _err =
         executor::block_on(framer.send("This will fill up the buffer\n".to_owned())).unwrap_err();
-    let (curs, _) = framer.release();
+    let curs = framer.into_inner();
     assert_eq!(curs.position(), 16);
     assert_eq!(&curs.get_ref()[0..16], b"This will fill u");
 }
@@ -93,7 +93,7 @@ fn send_high_water_mark() {
     let mut framer = FramedWrite::new(io, BytesCodec {});
     framer.set_send_high_water_mark(500);
     executor::block_on(framer.send_all(&mut stream)).unwrap();
-    let (io, _) = framer.release();
+    let io = framer.into_inner();
     assert_eq!(io.num_poll_write, 2);
     assert_eq!(io.last_write_size, 499);
 }

--- a/tests/length_delimited.rs
+++ b/tests/length_delimited.rs
@@ -14,7 +14,7 @@ fn same_msgs_are_received_as_were_sent() {
     };
     executor::block_on(send_msgs);
 
-    let (mut cur, _) = framed.release();
+    let mut cur = framed.into_inner();
     cur.set_position(0);
     let framed = Framed::new(cur, LengthCodec {});
 


### PR DESCRIPTION
Copy of https://github.com/matthunz/futures-codec/pull/54 by @romanb.

> This PR generalises `Framed::release()` et al to `Framed::into_parts()`, providing corresponding `Framed::from_parts`. This is pretty much analogous to `tokio_util::codec::FramedParts`. There are mainly two use-cases:
> 
>     1. Resuing framed buffers with a new codec ([tokio-rs/tokio#717](https://github.com/tokio-rs/tokio/issues/717)).
> 
>     2. Protocols that use a particular `Framed` only e.g. during a handshake phase after which they want to drop down to direct use of the underlying I/O stream. Since the `Framed` may have read and buffered data beyond the handshake frames, it is necessary to drain the remaining read buffer first when doing this. While one can already obtain the read buffer from `Framed::read_buffer()`, using it to capture the buffer before calling `Framed::into_inner()` requires to unnecessarily clone the `BytesMut`.
> 
> 
> I also tweaked the documentation a bit to make it clearer that the `into_inner()` methods may discard buffered data. Since this PR removes / renames `Framed::release()` et al to `into_parts`, the API changes are not backward-compatible.

@romanb do you consent to your work being used in `asynchronous-codec`?