### PR TITLE
[WIP] no_std traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,12 +13,14 @@ keywords = ["future", "futures", "async", "codec"]
 categories = ["asynchronous", "network-programming"]
 
 [features]
-default = []
-json = [ "serde", "serde_json" ]
-cbor = [ "serde", "serde_cbor" ]
+default = ["std"]
+std = ["alloc", "bytes/std"]
+alloc = []
+json = [ "std", "serde", "serde_json" ]
+cbor = [ "std", "serde", "serde_cbor" ]
 
 [dependencies]
-bytes = "1"
+bytes = { version = "1", default-features = false }
 futures-sink = "0.3"
 futures-util = { version = "0.3", features = ["io"] }
 memchr = "2"

--- a/src/codec/bytes.rs
+++ b/src/codec/bytes.rs
@@ -1,6 +1,6 @@
+use core::fmt::Debug;
 use crate::{Decoder, Encoder};
 use bytes::{Bytes, BytesMut};
-use std::io::Error;
 
 /// A simple codec that ships bytes around
 ///
@@ -11,7 +11,7 @@ use std::io::Error;
 /// use bytes::Bytes;
 /// use futures::{SinkExt, TryStreamExt};
 /// use futures::io::Cursor;
-/// use asynchronous_codec::{BytesCodec, Framed};
+/// use asynchronous_codec::{BytesCodec, Framed, FramedError};
 ///
 /// let mut buf = vec![];
 /// // Cursor implements AsyncRead and AsyncWrite
@@ -23,14 +23,17 @@ use std::io::Error;
 /// while let Some(bytes) = framed.try_next().await? {
 ///     dbg!(bytes);
 /// }
-/// # Ok::<_, std::io::Error>(())
+/// # Ok::<_, FramedError<BytesCodec>>(())
 /// # }).unwrap();
 /// ```
 pub struct BytesCodec;
 
+#[derive(Debug)]
+pub struct BytesError;
+
 impl Encoder for BytesCodec {
     type Item = Bytes;
-    type Error = Error;
+    type Error = BytesError;
 
     fn encode(&mut self, src: Self::Item, dst: &mut BytesMut) -> Result<(), Self::Error> {
         dst.extend_from_slice(&src);
@@ -40,7 +43,7 @@ impl Encoder for BytesCodec {
 
 impl Decoder for BytesCodec {
     type Item = Bytes;
-    type Error = Error;
+    type Error = BytesError;
 
     fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
         let len = src.len();

--- a/src/codec/cbor.rs
+++ b/src/codec/cbor.rs
@@ -15,7 +15,7 @@ use serde_cbor::Error as CborError;
 /// use serde::{Serialize, Deserialize};
 /// use asynchronous_codec::{CborCodec, Framed};
 ///
-/// #[derive(Serialize, Deserialize)]
+/// #[derive(Serialize, Deserialize, Debug)]
 /// struct Something {
 ///     pub data: u16,
 /// }
@@ -168,6 +168,7 @@ where
 
 #[cfg(test)]
 mod test {
+    use alloc::string::String;
     use bytes::BytesMut;
     use serde::{Deserialize, Serialize};
 
@@ -186,7 +187,7 @@ mod test {
         let mut buff = BytesMut::new();
 
         let item1 = TestStruct {
-            name: "Test name".to_owned(),
+            name: "Test name".into(),
             data: 16,
         };
         codec.encode(item1.clone(), &mut buff).unwrap();
@@ -205,7 +206,7 @@ mod test {
         let mut buff = BytesMut::new();
 
         let item1 = TestStruct {
-            name: "Test name".to_owned(),
+            name: "Test name".into(),
             data: 34,
         };
         codec.encode(item1, &mut buff).unwrap();

--- a/src/codec/json.rs
+++ b/src/codec/json.rs
@@ -1,8 +1,8 @@
-use std::marker::PhantomData;
+use std::io::Error as IoError;
+use core::marker::PhantomData;
 
 use crate::{Decoder, Encoder};
 use bytes::{Buf, BufMut, BytesMut};
-
 use serde::{Deserialize, Serialize};
 
 /// A codec for JSON encoding and decoding using serde_json
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 /// use serde::{Serialize, Deserialize};
 /// use asynchronous_codec::{JsonCodec, Framed};
 ///
-/// #[derive(Serialize, Deserialize)]
+/// #[derive(Serialize, Deserialize, Debug)]
 /// struct Something {
 ///     pub data: u16,
 /// }
@@ -40,7 +40,7 @@ pub struct JsonCodec<Enc, Dec> {
 #[derive(Debug)]
 pub enum JsonCodecError {
     /// IO error
-    Io(std::io::Error),
+    Io(IoError),
     /// JSON error
     Json(serde_json::Error),
 }
@@ -165,6 +165,7 @@ where
 
 #[cfg(test)]
 mod test {
+    use alloc::string::String;
     use bytes::BytesMut;
     use serde::{Deserialize, Serialize};
 
@@ -183,7 +184,7 @@ mod test {
         let mut buff = BytesMut::new();
 
         let item1 = TestStruct {
-            name: "Test name".to_owned(),
+            name: "Test name".into(),
             data: 16,
         };
         codec.encode(item1.clone(), &mut buff).unwrap();
@@ -202,7 +203,7 @@ mod test {
         let mut buff = BytesMut::new();
 
         let item1 = TestStruct {
-            name: "Test name".to_owned(),
+            name: "Test name".into(),
             data: 34,
         };
         codec.encode(item1, &mut buff).unwrap();

--- a/src/codec/length.rs
+++ b/src/codec/length.rs
@@ -1,3 +1,4 @@
+use core::fmt::Debug;
 use crate::{Decoder, Encoder};
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::io::Error;
@@ -44,6 +45,7 @@ const U64_LENGTH: usize = std::mem::size_of::<u64>();
 ///     }
 /// }
 /// ```
+#[derive(Debug)]
 pub struct LengthCodec;
 
 impl Encoder for LengthCodec {

--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -1,10 +1,14 @@
 mod bytes;
 pub use self::bytes::BytesCodec;
 
+#[cfg(feature = "std")]
 mod length;
+#[cfg(feature = "std")]
 pub use self::length::LengthCodec;
 
+#[cfg(feature = "alloc")]
 mod lines;
+#[cfg(feature = "alloc")]
 pub use self::lines::LinesCodec;
 
 #[cfg(feature = "json")]

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -1,14 +1,13 @@
-use super::framed_write::FramedWrite2;
-use super::fuse::Fuse;
+use core::fmt::Debug;
 use bytes::BytesMut;
-use std::io::Error;
+
 
 /// Decoding of frames via buffers, for use with `FramedRead`.
 pub trait Decoder {
     /// The type of items returned by `decode`
     type Item;
     /// The type of decoding errors.
-    type Error: From<Error>;
+    type Error: Debug;
 
     /// Decode an item from the src `BytesMut` into an item
     fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error>;
@@ -20,31 +19,5 @@ pub trait Decoder {
     /// The default implementation of this method invokes the `Decoder::decode` method.
     fn decode_eof(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
         self.decode(src)
-    }
-}
-
-impl<T, U: Decoder> Decoder for Fuse<T, U> {
-    type Item = U::Item;
-    type Error = U::Error;
-
-    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
-        self.u.decode(src)
-    }
-
-    fn decode_eof(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
-        self.u.decode_eof(src)
-    }
-}
-
-impl<T: Decoder> Decoder for FramedWrite2<T> {
-    type Item = T::Item;
-    type Error = T::Error;
-
-    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
-        self.inner.decode(src)
-    }
-
-    fn decode_eof(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
-        self.inner.decode_eof(src)
     }
 }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1,23 +1,13 @@
-use super::fuse::Fuse;
+use core::fmt::Debug;
 use bytes::BytesMut;
-use std::io::Error;
 
 /// Encoding of messages as bytes, for use with `FramedWrite`.
 pub trait Encoder {
     /// The type of items consumed by `encode`
     type Item;
     /// The type of encoding errors.
-    type Error: From<Error>;
+    type Error: Debug;
 
     /// Encodes an item into the `BytesMut` provided by dst.
     fn encode(&mut self, item: Self::Item, dst: &mut BytesMut) -> Result<(), Self::Error>;
-}
-
-impl<T, U: Encoder> Encoder for Fuse<T, U> {
-    type Item = U::Item;
-    type Error = U::Error;
-
-    fn encode(&mut self, item: Self::Item, dst: &mut BytesMut) -> Result<(), Self::Error> {
-        self.u.encode(item, dst)
-    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,10 +6,10 @@
 //! Framed streams are also known as `transports`.
 //!
 //! ```
-//! # futures::executor::block_on(async move {
+//! futures::executor::block_on(async move {
 //! use futures::TryStreamExt;
 //! use futures::io::Cursor;
-//! use asynchronous_codec::{LinesCodec, Framed};
+//! use asynchronous_codec::{LinesCodec, Framed, FramedError};
 //!
 //! let io = Cursor::new(Vec::new());
 //! let mut framed = Framed::new(io, LinesCodec);
@@ -17,12 +17,22 @@
 //! while let Some(line) = framed.try_next().await? {
 //!     dbg!(line);
 //! }
-//! # Ok::<_, std::io::Error>(())
+//! # Ok::<_, FramedError<LinesCodec>>(())
 //! # }).unwrap();
 //! ```
 
-mod codec;
+#![no_std]
+
+#[cfg(feature = "alloc")]
+extern crate alloc;
+#[cfg(feature = "std")]
+extern crate std;
+
 pub use bytes::{Bytes, BytesMut};
+
+mod codec;
+
+#[cfg(feature = "std")]
 pub use codec::{BytesCodec, LengthCodec, LinesCodec};
 
 #[cfg(feature = "cbor")]
@@ -36,13 +46,24 @@ pub use decoder::Decoder;
 mod encoder;
 pub use encoder::Encoder;
 
+#[cfg(feature = "std")]
 mod framed;
-pub use framed::{Framed, FramedParts};
 
+#[cfg(feature = "std")]
+pub use framed::{Framed, FramedParts, FramedError};
+
+
+#[cfg(feature = "std")]
 mod framed_read;
-pub use framed_read::{FramedRead, FramedReadParts};
 
+#[cfg(feature = "std")]
+pub use framed_read::{FramedRead, FramedReadParts, FramedReadError};
+
+#[cfg(feature = "std")]
 mod framed_write;
-pub use framed_write::{FramedWrite, FramedWriteParts};
 
+#[cfg(feature = "std")]
+pub use framed_write::{FramedWrite, FramedWriteParts, FramedWriteError};
+
+#[cfg(feature = "std")]
 mod fuse;


### PR DESCRIPTION
Hello.

I am trying to use this crate to write a library around a custom TCP protocol. Said protocol will likely be useful on both web servers and embedded devices (as long as said devices provide some sort of networking and a TCP stream implementation; think embassy-net), so I want to make it as portable as possible.

While I understand it might not be possible for it to be fully portable (e.g. Framed(Read/Write) are not embassy-net compatible, due to embassy-net not being AsyncRead/AsyncWrite compatible), it would still help a great deal if I can at least reuse the encoder and decoder, and just swap out a stream handler.

This PR is my attempt to do this (by getting rid of std::io::Error in encoder and decoder, and following the compiler warnings from there), but I am new to Rust, so I ended up with some errors related to Fuse, and yet occurring in FramedRead/FramedWrite, and I'm not sure how to deal with those yet.

I thought I share the progress so far, to ensure it's even worth pursuing this to its end, or if I should perhaps try to instead refactor async-codec to be splittable (which is the reason I ended here... Because I _also_ need a reader/writer split).