### PR TITLE
Fix: `eof` error handling when decoding in `CborCodec`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [0.6.2] - unreleased
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Error handling in `CborCodec` `decode` [#7](https://github.com/mxinden/asynchronous-codec/pull/7)
+
 ## [0.6.1] - 2022-11-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
-- Error handling in `CborCodec` `decode` [#7](https://github.com/mxinden/asynchronous-codec/pull/7)
+- Error handling in `CborCodec` and `JsonCodec` `decode` [#7](https://github.com/mxinden/asynchronous-codec/pull/7)
 
 ## [0.6.1] - 2022-11-08
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "asynchronous-codec"
 edition = "2018"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["Max Inden <mail@max-inden.de>"]
 description = "Utilities for encoding and decoding frames using `async/await`"
 license = "MIT"

--- a/src/codec/cbor.rs
+++ b/src/codec/cbor.rs
@@ -121,7 +121,7 @@ where
         // If we ran out before parsing, return none and try again later
         let res = match res {
             Ok(v) => Ok(Some(v)),
-            Err(e) if e.is_eof() => Ok(None),
+            Err(e) if e.is_eof() => return Ok(None),
             Err(e) => Err(e.into()),
         };
 

--- a/src/codec/cbor.rs
+++ b/src/codec/cbor.rs
@@ -119,10 +119,10 @@ where
         let res: Result<Dec, _> = serde::de::Deserialize::deserialize(&mut de);
 
         // If we ran out before parsing, return none and try again later
-        let res = match res {
-            Ok(v) => Ok(Some(v)),
+        let item = match res {
+            Ok(item) => item,
             Err(e) if e.is_eof() => return Ok(None),
-            Err(e) => Err(e.into()),
+            Err(e) => return Err(e.into()),
         };
 
         // Update offset from iterator
@@ -131,7 +131,7 @@ where
         // Advance buffer
         buf.advance(offset);
 
-        res
+        Ok(Some(item))
     }
 }
 
@@ -259,8 +259,10 @@ mod test {
 
         // Split the end off the buffer.
         let mut buff_end = buff.clone().split_off(4);
+        let buff_end_length = buff_end.len();
 
         // Attempting to decode should return an error.
         assert!(codec.decode(&mut buff_end).is_err());
+        assert_eq!(buff_end.len(), buff_end_length);
     }
 }


### PR DESCRIPTION
Closes: https://github.com/mxinden/asynchronous-codec/issues/6

- [x] `return` when decoding is `eof` and don't advance the buffer
- [x] tests for this and other error cases 
- [x] update `CHANGLOG` 