### PR TITLE
feat: relax trait bounds on `map_codec`

### DIFF
--- a/src/framed.rs
+++ b/src/framed.rs
@@ -204,7 +204,6 @@ impl<T, U> FramedParts<T, U> {
     /// Changes the codec used in this `FramedParts`.
     pub fn map_codec<V, F>(self, f: F) -> FramedParts<T, V>
     where
-        V: Encoder + Decoder,
         F: FnOnce(U) -> V,
     {
         FramedParts {


### PR DESCRIPTION
These trait-bounds are unnecessarily restrictive and don't need to be on this function. If the user maps to a type that doesn't implement `Encoder` + `Decoder`, they end up with an unusable type. However, this may sometimes be desired.

For example, in https://github.com/libp2p/rust-libp2p/pull/4548, mapping the codec is a fallible function that returns a tuple where only one part is the codec. This is hard to express in a general way which is why https://github.com/mxinden/asynchronous-codec/pull/10 got closed.

However, if we relax these trait-bounds, the codec can be mapped to an `Option<T>` and extracted via `mem::replace`.