### PR TITLE
Significant Read Performance Improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ futures-sink = "0.3"
 futures-util = { version = "0.3", features = ["io"] }
 memchr = "2"
 pin-project-lite = "0.2"
+uninit-read = "0.1"
 
 [dev-dependencies]
 futures = "0.3"

--- a/src/framed.rs
+++ b/src/framed.rs
@@ -143,13 +143,6 @@ where
         self.inner.buffer()
     }
 
-    /// Disables zero-initialization of newly allocated read buffer capacity.
-    ///
-    /// See [`FramedRead::disable_buffer_initialization`].
-    pub unsafe fn disable_read_buffer_initialization(&mut self) {
-        self.inner.disable_buffer_initialization()
-    }
-
     /// Sets the buffer capacity for read operations.
     ///
     /// See [`FramedRead::set_capacity`].

--- a/src/framed.rs
+++ b/src/framed.rs
@@ -12,6 +12,13 @@ use std::ops::{Deref, DerefMut};
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
+// Needed only for doc links
+// Otherwise the `See` links won't resolve
+#[allow(unused_imports)]
+use super::framed_read::FramedRead;
+#[allow(unused_imports)]
+use super::framed_write::FramedWrite;
+
 pin_project! {
     /// A unified `Stream` and `Sink` interface to an underlying I/O object,
     /// using the `Encoder` and `Decoder` traits to encode and decode frames.
@@ -134,6 +141,20 @@ where
     /// Returns a reference to the read buffer.
     pub fn read_buffer(&self) -> &BytesMut {
         self.inner.buffer()
+    }
+
+    /// Disables zero-initialization of newly allocated read buffer capacity.
+    ///
+    /// See [`FramedRead::disable_buffer_initialization`].
+    pub unsafe fn disable_read_buffer_initialization(&mut self) {
+        self.inner.disable_buffer_initialization()
+    }
+
+    /// Sets the buffer capacity for read operations.
+    ///
+    /// See [`FramedRead::set_capacity`].
+    pub fn set_read_capacity(&mut self, capacity: usize) {
+        self.inner.set_capacity(capacity)
     }
 
     /// High-water mark for writes, in bytes

--- a/src/framed_read.rs
+++ b/src/framed_read.rs
@@ -206,8 +206,7 @@ where
                 this.ensure_safe_buf_capacity(this.capacity);
             }
 
-            // Create a mutable slice pointing to the buffer's potentially
-            // uninitialized spare capacity.
+            // Create a mutable slice pointing to the buffer's spare capacity.
             //
             // SAFETY: the previous call to `[ensure_safe_buf_capacity]` ensures
             // all bytes of the buffer are initialized.
@@ -222,7 +221,7 @@ where
                 "reader returned invalid number of bytes read"
             );
 
-            // SAFETY: The `poll_read` call has read `n` bytes of the buffer.
+            // SAFETY: The `poll_read` call has filled `n` bytes of the buffer.
             // We can now safely advance the buffer's length to make these bytes
             // available for consumption by the decoder.
             unsafe {

--- a/src/framed_read.rs
+++ b/src/framed_read.rs
@@ -1,7 +1,7 @@
 use super::fuse::Fuse;
 use super::Decoder;
 
-use bytes::BytesMut;
+use bytes::{BufMut, BytesMut};
 use futures_sink::Sink;
 use futures_util::io::AsyncRead;
 use futures_util::ready;
@@ -190,15 +190,40 @@ where
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = &mut *self;
 
+        // Attempt to decode a frame from the existing buffer first.
         if let Some(item) = this.inner.decode(&mut this.buffer)? {
             return Poll::Ready(Some(Ok(item)));
         }
 
-        let mut buf = vec![0x00; this.capacity];
+        // Reserve buffer space to avoid frequent reallocations.
+        this.buffer.reserve(this.capacity);
 
         loop {
-            let n = ready!(Pin::new(&mut this.inner).poll_read(cx, &mut buf))?;
-            this.buffer.extend_from_slice(&buf[..n]);
+            // If the buffer has no more spare capacity, reserve more.
+            // This prevents passing a zero-length slice to `poll_read`.
+            if !this.buffer.has_remaining_mut() {
+                // buffer is full
+                this.buffer.reserve(this.capacity);
+            }
+
+            // Create a mutable slice pointing to the buffer's potentially
+            // uninitialized spare capacity.
+            //
+            // SAFETY: This code relies on the de-facto contract that `poll_read`
+            // implementations will not read from the buffer before writing to it.
+            let buf = unsafe {
+                let chunk = this.buffer.chunk_mut();
+                std::slice::from_raw_parts_mut(chunk.as_mut_ptr(), chunk.len())
+            };
+
+            let n = ready!(Pin::new(&mut this.inner).poll_read(cx, buf))?;
+
+            // SAFETY: The `poll_read` call has initialized `n` bytes of the buffer.
+            // We can now safely advance the buffer's length to make these bytes
+            // available for consumption by the decoder.
+            unsafe {
+                this.buffer.advance_mut(n);
+            }
 
             let ended = n == 0;
 

--- a/src/framed_read.rs
+++ b/src/framed_read.rs
@@ -124,25 +124,6 @@ where
         &self.inner.buffer
     }
 
-    /// Disables zero-initialization of newly allocated buffer capacity.
-    ///
-    /// # Safety
-    ///
-    /// The caller must guarantee that the underlying `AsyncRead` implementation
-    /// will never read from the buffer before writing to it. Violating this
-    /// contract results in undefined behavior as uninitialized memory may be read.
-    ///
-    /// Most well-behaved `AsyncRead` implementations satisfy this requirement,
-    /// but some implementations may not.
-    ///
-    /// # Performance
-    ///
-    /// Disabling initialization can provide significant performance improvements
-    /// for high-throughput scenarios by eliminating memory zeroing overhead.
-    pub unsafe fn disable_buffer_initialization(&mut self) {
-        self.inner.disable_buffer_initialization()
-    }
-
     /// Sets the buffer capacity for read operations.
     ///
     /// This determines how many bytes will be reserved when the buffer needs
@@ -175,7 +156,7 @@ pin_project! {
         inner: T,
         buffer: BytesMut,
         capacity: usize,
-        buffer_init_disabled: bool,
+        allow_uninit_read: bool,
     }
 }
 
@@ -198,18 +179,18 @@ const DEFAULT_CAPACITY: usize = 8 * 1024;
 pub fn framed_read_2<T>(inner: T, buffer: Option<BytesMut>) -> FramedRead2<T> {
     let mut buffer = buffer.unwrap_or_else(|| BytesMut::new());
 
-    // Disabled buffer initialization if the inner reader is known to be safe.
-    let buffer_init_disabled = is_uninit_read::<T>();
+    // Allow using uninitialized read buffers if the inner reader is known to be safe.
+    let allow_uninit_read = is_uninit_read::<T>();
 
     // Ensure any spare capacity of the supplied buffer is initialized if necessary.
-    if !buffer_init_disabled {
+    if !allow_uninit_read {
         init_buffer(buffer.spare_capacity_mut());
     }
     FramedRead2 {
         inner,
         capacity: DEFAULT_CAPACITY,
         buffer,
-        buffer_init_disabled,
+        allow_uninit_read,
     }
 }
 
@@ -234,7 +215,7 @@ where
                 // No spare capacity left, reserve a new chunk of `this.capacity` bytes.
                 this.buffer.reserve(this.capacity);
                 let spare = this.buffer.spare_capacity_mut();
-                if !spare.is_empty() && !this.buffer_init_disabled {
+                if !spare.is_empty() && !this.allow_uninit_read {
                     // Initialize the new capacity to avoid the risk of UB.
                     init_buffer(spare);
                 }
@@ -319,10 +300,6 @@ impl<T> FramedRead2<T> {
 
     pub fn buffer(&self) -> &BytesMut {
         &self.buffer
-    }
-
-    pub unsafe fn disable_buffer_initialization(&mut self) {
-        self.buffer_init_disabled = true;
     }
 
     pub fn set_capacity(&mut self, capacity: usize) {

--- a/src/framed_read.rs
+++ b/src/framed_read.rs
@@ -13,6 +13,7 @@ use std::mem::MaybeUninit;
 use std::ops::{Deref, DerefMut};
 use std::pin::Pin;
 use std::task::{Context, Poll};
+use uninit_read::is_uninit_read;
 
 /// A `Stream` of messages decoded from an `AsyncRead`.
 ///
@@ -196,13 +197,19 @@ const DEFAULT_CAPACITY: usize = 8 * 1024;
 
 pub fn framed_read_2<T>(inner: T, buffer: Option<BytesMut>) -> FramedRead2<T> {
     let mut buffer = buffer.unwrap_or_else(|| BytesMut::new());
-    // Ensure any spare capacity of the supplied buffer is initialized.
-    init_buffer(buffer.spare_capacity_mut());
+
+    // Disabled buffer initialization if the inner reader is known to be safe.
+    let buffer_init_disabled = is_uninit_read::<T>();
+
+    // Ensure any spare capacity of the supplied buffer is initialized if necessary.
+    if !buffer_init_disabled {
+        init_buffer(buffer.spare_capacity_mut());
+    }
     FramedRead2 {
         inner,
         capacity: DEFAULT_CAPACITY,
         buffer,
-        buffer_init_disabled: false,
+        buffer_init_disabled,
     }
 }
 

--- a/src/framed_read.rs
+++ b/src/framed_read.rs
@@ -192,23 +192,15 @@ impl<T> DerefMut for FramedRead2<T> {
     }
 }
 
-const INITIAL_CAPACITY: usize = 8 * 1024;
+const DEFAULT_CAPACITY: usize = 8 * 1024;
 
 pub fn framed_read_2<T>(inner: T, buffer: Option<BytesMut>) -> FramedRead2<T> {
-    let buffer = buffer.unwrap_or_else(|| BytesMut::new());
-    framed_read_2_with_capacity(inner, buffer, INITIAL_CAPACITY)
-}
-
-fn framed_read_2_with_capacity<T>(
-    inner: T,
-    mut buffer: BytesMut,
-    capacity: usize,
-) -> FramedRead2<T> {
+    let mut buffer = buffer.unwrap_or_else(|| BytesMut::new());
     // Ensure any spare capacity of the supplied buffer is initialized.
     init_buffer(buffer.spare_capacity_mut());
     FramedRead2 {
         inner,
-        capacity,
+        capacity: DEFAULT_CAPACITY,
         buffer,
         buffer_init_disabled: false,
     }

--- a/src/framed_read.rs
+++ b/src/framed_read.rs
@@ -134,6 +134,25 @@ where
     pub fn read_buffer(&self) -> &BytesMut {
         &self.inner.buffer
     }
+
+    /// Disables zero-initialization of newly allocated buffer capacity.
+    ///
+    /// # Safety
+    ///
+    /// The caller must guarantee that the underlying `AsyncRead` implementation
+    /// will never read from the buffer before writing to it. Violating this
+    /// contract results in undefined behavior as uninitialized memory may be read.
+    ///
+    /// Most well-behaved `AsyncRead` implementations satisfy this requirement,
+    /// but some implementations may not.
+    ///
+    /// # Performance
+    ///
+    /// Disabling initialization can provide significant performance improvements
+    /// for high-throughput scenarios by eliminating memory zeroing overhead.
+    pub unsafe fn disable_buffer_initialization(&mut self) {
+        self.inner.buffer_init_disabled = true;
+    }
 }
 
 impl<T, D> Stream for FramedRead<T, D>
@@ -155,6 +174,7 @@ pin_project! {
         inner: T,
         buffer: BytesMut,
         capacity: usize,
+        buffer_init_disabled: bool,
     }
 }
 
@@ -190,6 +210,7 @@ fn framed_read_2_with_capacity<T>(
         inner,
         capacity,
         buffer,
+        buffer_init_disabled: false,
     }
 }
 
@@ -214,8 +235,7 @@ where
                 // No spare capacity left, reserve a new chunk of `this.capacity` bytes.
                 this.buffer.reserve(this.capacity);
                 let spare = this.buffer.spare_capacity_mut();
-                if !spare.is_empty() {
-                    // Spare capacity has increased.
+                if !spare.is_empty() && !this.buffer_init_disabled {
                     // Initialize the new capacity to avoid the risk of UB.
                     init_buffer(spare);
                 }

--- a/src/framed_read.rs
+++ b/src/framed_read.rs
@@ -63,26 +63,6 @@ where
         }
     }
 
-    /// Creates a new `FramedRead` transport with the given `Decoder`
-    /// and specified buffer capacity.
-    ///
-    /// `capacity` determines how many bytes will be reserved when the buffer needs
-    /// to grow. Larger capacities reduce allocation frequency but use more memory.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `capacity` is zero.
-    pub fn with_capacity(inner: T, decoder: D, capacity: usize) -> Self {
-        assert!(capacity > 0);
-        Self {
-            inner: framed_read_2_with_capacity(
-                Fuse::new(inner, decoder),
-                BytesMut::new(),
-                capacity,
-            ),
-        }
-    }
-
     /// Creates a new `FramedRead` from [`FramedReadParts`].
     ///
     /// See also [`FramedRead::into_parts`].
@@ -159,7 +139,7 @@ where
     /// Disabling initialization can provide significant performance improvements
     /// for high-throughput scenarios by eliminating memory zeroing overhead.
     pub unsafe fn disable_buffer_initialization(&mut self) {
-        self.inner.buffer_init_disabled = true;
+        self.inner.disable_buffer_initialization()
     }
 
     /// Sets the buffer capacity for read operations.
@@ -171,8 +151,7 @@ where
     ///
     /// Panics if `capacity` is zero.
     pub fn set_capacity(&mut self, capacity: usize) {
-        assert!(capacity > 0);
-        self.inner.capacity = capacity
+        self.inner.set_capacity(capacity)
     }
 }
 
@@ -341,6 +320,15 @@ impl<T> FramedRead2<T> {
 
     pub fn buffer(&self) -> &BytesMut {
         &self.buffer
+    }
+
+    pub unsafe fn disable_buffer_initialization(&mut self) {
+        self.buffer_init_disabled = true;
+    }
+
+    pub fn set_capacity(&mut self, capacity: usize) {
+        assert!(capacity > 0);
+        self.capacity = capacity
     }
 }
 

--- a/src/framed_read.rs
+++ b/src/framed_read.rs
@@ -62,6 +62,17 @@ where
         }
     }
 
+    /// Creates a new `FramedRead` transport with the given `Decoder`
+    /// and a buffer of capacity initial size.
+    pub fn with_capacity(inner: T, decoder: D, capacity: usize) -> Self {
+        Self {
+            inner: framed_read_2(
+                Fuse::new(inner, decoder),
+                Some(BytesMut::with_capacity(capacity)),
+            ),
+        }
+    }
+
     /// Creates a new `FramedRead` from [`FramedReadParts`].
     ///
     /// See also [`FramedRead::into_parts`].
@@ -141,6 +152,7 @@ pin_project! {
         #[pin]
         inner: T,
         buffer: BytesMut,
+        capacity: usize,
     }
 }
 
@@ -161,9 +173,11 @@ impl<T> DerefMut for FramedRead2<T> {
 const INITIAL_CAPACITY: usize = 8 * 1024;
 
 pub fn framed_read_2<T>(inner: T, buffer: Option<BytesMut>) -> FramedRead2<T> {
+    let buffer = buffer.unwrap_or_else(|| BytesMut::with_capacity(INITIAL_CAPACITY));
     FramedRead2 {
         inner,
-        buffer: buffer.unwrap_or_else(|| BytesMut::with_capacity(INITIAL_CAPACITY)),
+        capacity: buffer.capacity(),
+        buffer,
     }
 }
 
@@ -180,7 +194,7 @@ where
             return Poll::Ready(Some(Ok(item)));
         }
 
-        let mut buf = [0u8; INITIAL_CAPACITY];
+        let mut buf = vec![0x00; this.capacity];
 
         loop {
             let n = ready!(Pin::new(&mut this.inner).poll_read(cx, &mut buf))?;

--- a/src/framed_read.rs
+++ b/src/framed_read.rs
@@ -264,8 +264,11 @@ where
 
             // Create a mutable slice pointing to the buffer's spare capacity.
             //
-            // SAFETY: the previous call to `[ensure_safe_buf_capacity]` ensures
-            // all bytes of the buffer are initialized.
+            // SAFETY: This is safe because either:
+            // a) a previous call to `init_buffer` has zero-initialized
+            //    all spare capacity bytes, or
+            // b) buffer initialization was disabled but the caller guarantees the
+            //    underlying AsyncRead will not read from the buffer before writing to it.
             let buf = unsafe {
                 let chunk = this.buffer.spare_capacity_mut();
                 std::slice::from_raw_parts_mut(chunk.as_mut_ptr() as *mut _, chunk.len())

--- a/src/framed_read.rs
+++ b/src/framed_read.rs
@@ -217,6 +217,10 @@ where
             };
 
             let n = ready!(Pin::new(&mut this.inner).poll_read(cx, buf))?;
+            assert!(
+                n <= buf.len(),
+                "reader returned invalid number of bytes read"
+            );
 
             // SAFETY: The `poll_read` call has initialized `n` bytes of the buffer.
             // We can now safely advance the buffer's length to make these bytes

--- a/src/framed_read.rs
+++ b/src/framed_read.rs
@@ -64,8 +64,16 @@ where
     }
 
     /// Creates a new `FramedRead` transport with the given `Decoder`
-    /// and a buffer of capacity initial size.
+    /// and specified buffer capacity.
+    ///
+    /// `capacity` determines how many bytes will be reserved when the buffer needs
+    /// to grow. Larger capacities reduce allocation frequency but use more memory.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `capacity` is zero.
     pub fn with_capacity(inner: T, decoder: D, capacity: usize) -> Self {
+        assert!(capacity > 0);
         Self {
             inner: framed_read_2_with_capacity(
                 Fuse::new(inner, decoder),
@@ -152,6 +160,19 @@ where
     /// for high-throughput scenarios by eliminating memory zeroing overhead.
     pub unsafe fn disable_buffer_initialization(&mut self) {
         self.inner.buffer_init_disabled = true;
+    }
+
+    /// Sets the buffer capacity for read operations.
+    ///
+    /// This determines how many bytes will be reserved when the buffer needs
+    /// to grow. Larger capacities reduce allocation frequency but use more memory.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `capacity` is zero.
+    pub fn set_capacity(&mut self, capacity: usize) {
+        assert!(capacity > 0);
+        self.inner.capacity = capacity
     }
 }
 

--- a/src/framed_read.rs
+++ b/src/framed_read.rs
@@ -9,6 +9,7 @@ use futures_util::stream::{Stream, TryStreamExt};
 use pin_project_lite::pin_project;
 use std::io;
 use std::marker::Unpin;
+use std::mem::MaybeUninit;
 use std::ops::{Deref, DerefMut};
 use std::pin::Pin;
 use std::task::{Context, Poll};
@@ -66,9 +67,10 @@ where
     /// and a buffer of capacity initial size.
     pub fn with_capacity(inner: T, decoder: D, capacity: usize) -> Self {
         Self {
-            inner: framed_read_2(
+            inner: framed_read_2_with_capacity(
                 Fuse::new(inner, decoder),
-                Some(BytesMut::with_capacity(capacity)),
+                BytesMut::new(),
+                capacity,
             ),
         }
     }
@@ -173,10 +175,20 @@ impl<T> DerefMut for FramedRead2<T> {
 const INITIAL_CAPACITY: usize = 8 * 1024;
 
 pub fn framed_read_2<T>(inner: T, buffer: Option<BytesMut>) -> FramedRead2<T> {
-    let buffer = buffer.unwrap_or_else(|| BytesMut::with_capacity(INITIAL_CAPACITY));
+    let buffer = buffer.unwrap_or_else(|| BytesMut::new());
+    framed_read_2_with_capacity(inner, buffer, INITIAL_CAPACITY)
+}
+
+fn framed_read_2_with_capacity<T>(
+    inner: T,
+    mut buffer: BytesMut,
+    capacity: usize,
+) -> FramedRead2<T> {
+    // Ensure any spare capacity of the supplied buffer is initialized.
+    init_buffer(buffer.spare_capacity_mut());
     FramedRead2 {
         inner,
-        capacity: buffer.capacity(),
+        capacity,
         buffer,
     }
 }
@@ -195,15 +207,18 @@ where
             return Poll::Ready(Some(Ok(item)));
         }
 
-        // Reserve buffer space to avoid frequent reallocations.
-        this.ensure_safe_buf_capacity(this.capacity);
-
         loop {
             // If the buffer has no more spare capacity, reserve more.
             // This prevents passing a zero-length slice to `poll_read`.
             if this.buffer.spare_capacity_mut().is_empty() {
-                // buffer is full
-                this.ensure_safe_buf_capacity(this.capacity);
+                // No spare capacity left, reserve a new chunk of `this.capacity` bytes.
+                this.buffer.reserve(this.capacity);
+                let spare = this.buffer.spare_capacity_mut();
+                if !spare.is_empty() {
+                    // Spare capacity has increased.
+                    // Initialize the new capacity to avoid the risk of UB.
+                    init_buffer(spare);
+                }
             }
 
             // Create a mutable slice pointing to the buffer's spare capacity.
@@ -283,26 +298,6 @@ impl<T> FramedRead2<T> {
     pub fn buffer(&self) -> &BytesMut {
         &self.buffer
     }
-
-    fn ensure_safe_buf_capacity(&mut self, required_capacity: usize) {
-        let existing_capacity = self.buffer.spare_capacity_mut().len();
-        if required_capacity > existing_capacity {
-            self.buffer.reserve(required_capacity);
-
-            let spare = self.buffer.spare_capacity_mut();
-
-            if spare.len() > existing_capacity {
-                // SAFETY: We're zero-initializing newly allocated uninitialized memory.
-                // The slice bounds are guaranteed valid since we're using a subslice
-                // of spare_capacity_mut(), and writing to MaybeUninit<u8> as u8 is safe.
-                unsafe {
-                    let uninit = &mut spare[existing_capacity..];
-                    // Zero-initialize all spare capacity after the existing capacity
-                    std::ptr::write_bytes(uninit.as_mut_ptr() as *mut u8, 0x00, uninit.len());
-                }
-            }
-        }
-    }
 }
 
 /// The parts obtained from (FramedRead::into_parts).
@@ -331,5 +326,14 @@ impl<T, D> FramedReadParts<T, D> {
             buffer: self.buffer,
             _priv: (),
         }
+    }
+}
+
+#[inline]
+fn init_buffer(uninit: &mut [MaybeUninit<u8>]) {
+    // SAFETY: We're zero-initializing possibly uninitialized memory.
+    // The slice bounds are guaranteed valid and writing to MaybeUninit<u8> as u8 is safe.
+    unsafe {
+        std::ptr::write_bytes(uninit.as_mut_ptr() as *mut u8, 0x00, uninit.len());
     }
 }

--- a/src/framed_read.rs
+++ b/src/framed_read.rs
@@ -196,24 +196,24 @@ where
         }
 
         // Reserve buffer space to avoid frequent reallocations.
-        this.buffer.reserve(this.capacity);
+        this.ensure_safe_buf_capacity(this.capacity);
 
         loop {
             // If the buffer has no more spare capacity, reserve more.
             // This prevents passing a zero-length slice to `poll_read`.
             if this.buffer.spare_capacity_mut().is_empty() {
                 // buffer is full
-                this.buffer.reserve(this.capacity);
+                this.ensure_safe_buf_capacity(this.capacity);
             }
 
             // Create a mutable slice pointing to the buffer's potentially
             // uninitialized spare capacity.
             //
-            // SAFETY: This code relies on the de-facto contract that `poll_read`
-            // implementations will not read from the buffer before writing to it.
+            // SAFETY: the previous call to `[ensure_safe_buf_capacity]` ensures
+            // all bytes of the buffer are initialized.
             let buf = unsafe {
-                let chunk = this.buffer.chunk_mut();
-                std::slice::from_raw_parts_mut(chunk.as_mut_ptr(), chunk.len())
+                let chunk = this.buffer.spare_capacity_mut();
+                std::slice::from_raw_parts_mut(chunk.as_mut_ptr() as *mut _, chunk.len())
             };
 
             let n = ready!(Pin::new(&mut this.inner).poll_read(cx, buf))?;
@@ -222,7 +222,7 @@ where
                 "reader returned invalid number of bytes read"
             );
 
-            // SAFETY: The `poll_read` call has initialized `n` bytes of the buffer.
+            // SAFETY: The `poll_read` call has read `n` bytes of the buffer.
             // We can now safely advance the buffer's length to make these bytes
             // available for consumption by the decoder.
             unsafe {
@@ -283,6 +283,26 @@ impl<T> FramedRead2<T> {
 
     pub fn buffer(&self) -> &BytesMut {
         &self.buffer
+    }
+
+    fn ensure_safe_buf_capacity(&mut self, required_capacity: usize) {
+        let existing_capacity = self.buffer.spare_capacity_mut().len();
+        if required_capacity > existing_capacity {
+            self.buffer.reserve(required_capacity);
+
+            let spare = self.buffer.spare_capacity_mut();
+
+            if spare.len() > existing_capacity {
+                // SAFETY: We're zero-initializing newly allocated uninitialized memory.
+                // The slice bounds are guaranteed valid since we're using a subslice
+                // of spare_capacity_mut(), and writing to MaybeUninit<u8> as u8 is safe.
+                unsafe {
+                    let uninit = &mut spare[existing_capacity..];
+                    // Zero-initialize all spare capacity after the existing capacity
+                    std::ptr::write_bytes(uninit.as_mut_ptr() as *mut u8, 0x00, uninit.len());
+                }
+            }
+        }
     }
 }
 

--- a/src/framed_read.rs
+++ b/src/framed_read.rs
@@ -201,7 +201,7 @@ where
         loop {
             // If the buffer has no more spare capacity, reserve more.
             // This prevents passing a zero-length slice to `poll_read`.
-            if !this.buffer.has_remaining_mut() {
+            if this.buffer.spare_capacity_mut().is_empty() {
                 // buffer is full
                 this.buffer.reserve(this.capacity);
             }

--- a/src/framed_write.rs
+++ b/src/framed_write.rs
@@ -10,6 +10,7 @@ use std::marker::Unpin;
 use std::ops::{Deref, DerefMut};
 use std::pin::Pin;
 use std::task::{Context, Poll};
+use uninit_read::UninitRead;
 
 pin_project! {
     /// A `Sink` of frames encoded to an `AsyncWrite`.
@@ -265,6 +266,8 @@ where
         self.project().inner.poll_close(cx).map_err(Into::into)
     }
 }
+
+unsafe impl<T: UninitRead> UninitRead for FramedWrite2<T> {}
 
 impl<T> FramedWrite2<T> {
     pub fn into_parts(self) -> (T, BytesMut) {

--- a/src/fuse.rs
+++ b/src/fuse.rs
@@ -5,6 +5,7 @@ use std::marker::Unpin;
 use std::ops::{Deref, DerefMut};
 use std::pin::Pin;
 use std::task::{Context, Poll};
+use uninit_read::UninitRead;
 
 pin_project! {
     #[derive(Debug)]
@@ -60,3 +61,5 @@ impl<T: AsyncWrite + Unpin, U> AsyncWrite for Fuse<T, U> {
         self.project().t.poll_close(cx)
     }
 }
+
+unsafe impl<T: UninitRead, U> UninitRead for Fuse<T, U> {}

--- a/tests/framed_read.rs
+++ b/tests/framed_read.rs
@@ -5,6 +5,7 @@ use futures::AsyncRead;
 use std::io;
 use std::pin::Pin;
 use std::task::{Context, Poll};
+use uninit_read::UninitRead;
 
 // Sends two lines at once, then nothing else forever
 struct MockBurstySender {
@@ -55,6 +56,8 @@ impl AsyncRead for OneByteAtATime<'_> {
         }
     }
 }
+
+unsafe impl UninitRead for OneByteAtATime<'_> {}
 
 /// A decoder that only returns `a` characters from the input.
 struct AllTheAs;


### PR DESCRIPTION
I recently noticed `asynchronous-codec` was performing slower than anticipated in a project I'm working on, read operations in particular. To get a better sense of things, I compared its performance against `tokio-codec`, which gave me the throughput I had been expecting for my workload.

After some digging and experimentation, I've ended up with two changes that, when combined, appear to bring `asynchronous-codec`'s read performance effectively on par with `tokio-codec`.

**Here's a quick overview of the changes:**

1.  **Configurable Read Buffer Capacity:** I've introduced a new constructor, `FramedRead::with_capacity`, which allows users to specify the initial size of the internal read buffer. Previously, this was hardcoded to 8KiB. This is similar to what `tokio-codec` does and allows fine tuning for different workloads. 
2.  **Zero-Copy Reads:** The internal read mechanism has been optimized to avoid an unnecessary data copy. Data is now read directly from the underlying `AsyncRead` source into `FramedRead`'s internal `BytesMut` buffer. This eliminates an intermediate allocation and copy for each read operation. However, it does require some `unsafe` Rust, and it relies on the *de-facto* contract that `futures::io::AsyncRead` implementations will only *write* to the provided buffer and not read from its potentially uninitialized parts.

Some benchmarks to illustrate the impact of these changes:

### Performance Benchmarks

The benchmark involves reading a 3 GiB file from fast, local NVMe storage. The `BytesCodec` is used to frame the data.

#### Debug Build Benchmarks

| Version | Buffer Size | Average Throughput (MiB/s) | Diff vs. Unmodified (%) | Diff vs. Tokio-codec (64KiB) (%) |
| :------------ | :---------- | :------------------------- | :-------------------- | :------------------------------- |
| `async-codec` (Unmodified) | 8KiB | 475.76 | 0.0% | -83.8% |
| `async-codec` (configurable buffer) | 8KiB | 500.92 | 5.3% | -82.9% |
| `async-codec` (configurable buffer) | 64KiB | 2297.17 | 382.8% | -21.7% |
| `async-codec` (configurable + zero copy) | 8KiB | 536.70 | 12.8% | -81.7% |
| `async-codec` (configurable + zero copy) | 64KiB | **2932.17** | 516.3% | 0.0% |
| `tokio-codec` | 8KiB | 541.91 | 13.9% | -81.5% |
| `tokio-codec` | 64KiB | 2932.17 | 516.3% | 0.0% |

#### Release Build Benchmarks

| Version | Buffer Size | Average Throughput (MiB/s) | Diff vs. Unmodified (%) | Diff vs. Tokio-codec (64KiB) (%) |
| :------------ | :---------- | :------------------------- | :-------------------- | :------------------------------- |
| `async-codec` (Unmodified) | 8KiB | 841.58 | 0.0% | -78.0% |
| `async-codec` (configurable buffer) | 8KiB | 871.21 | 3.5% | -77.2% |
| `async-codec` (configurable buffer) | 64KiB | 3266.56 | 288.1% | -14.5% |
| `async-codec` (configurable + zero copy) | 8KiB | 886.15 | 5.3% | -76.8% |
| `async-codec` (configurable + zero copy) | 64KiB | **3966.25** | 371.3% | 3.8% |
| `tokio-codec` | 8KiB | 906.72 | 7.7% | -76.3% |
| `tokio-codec` | 64KiB | 3819.52 | 353.8% | 0.0% |

For my workload, reads are now around **500%** faster than before. Overall, `asychronous-codec`'s read performance is now on par with `tokio-codec`.